### PR TITLE
Populate dummy data for demo pages

### DIFF
--- a/src/data/dummyConversations.ts
+++ b/src/data/dummyConversations.ts
@@ -1,0 +1,33 @@
+export interface DummyConversation {
+  id: number;
+  participantId: number;
+  lastMessage: string;
+  unreadCount: number;
+}
+
+import { dummyUsers } from './dummyUsers';
+
+export const dummyConversations: DummyConversation[] = [
+  {
+    id: 1,
+    participantId: 2,
+    lastMessage: 'Hey there! How are you?',
+    unreadCount: 1,
+  },
+  {
+    id: 2,
+    participantId: 3,
+    lastMessage: 'Let\'s grab coffee soon.',
+    unreadCount: 0,
+  },
+  {
+    id: 3,
+    participantId: 5,
+    lastMessage: 'Great workout session yesterday!',
+    unreadCount: 3,
+  },
+];
+
+export function getConversationUser(conversation: DummyConversation) {
+  return dummyUsers.find((u) => u.id === conversation.participantId)!;
+}

--- a/src/data/dummyMatches.ts
+++ b/src/data/dummyMatches.ts
@@ -1,0 +1,1 @@
+export { dummyUsers as dummyMatches } from './dummyUsers';

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -1,17 +1,37 @@
 import React from 'react';
+import { dummyConversations, getConversationUser } from '../data/dummyConversations';
+import { useNavigate } from 'react-router-dom';
 
 function Chats() {
+  const navigate = useNavigate();
+
   return (
     <div className="min-h-screen bg-background">
       <div className="h-14 bg-white shadow-sm fixed top-0 left-0 right-0 flex items-center px-4">
         <h1 className="text-lg font-bold text-center flex-1">Chats</h1>
       </div>
-      
-      <div className="pt-14 px-4">
-        <div className="flex flex-col items-center justify-center min-h-[60vh]">
-          <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="#666666" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-          <p className="text-gray mt-4">No conversations yet. Matches you like will appear here.</p>
-        </div>
+
+      <div className="pt-14 px-4 space-y-2">
+        {dummyConversations.map((c) => {
+          const user = getConversationUser(c);
+          return (
+            <div key={c.id} className="card flex items-center space-x-4">
+              <img src={user.avatar} alt={user.displayName} className="w-12 h-12 rounded-full" />
+              <div className="flex-1 overflow-hidden">
+                <h3 className="font-medium">{user.displayName}</h3>
+                <p className="text-sm text-gray-600 truncate">
+                  {c.lastMessage}
+                </p>
+              </div>
+              {c.unreadCount > 0 && (
+                <span className="ml-2 text-xs bg-primary text-white rounded-full px-2 py-0.5">
+                  {c.unreadCount}
+                </span>
+              )}
+              <button className="btn text-sm px-3 py-1 h-auto" onClick={() => navigate('/chats')}>Open</button>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/pages/Matches.tsx
+++ b/src/pages/Matches.tsx
@@ -1,20 +1,27 @@
 import React from 'react';
+import { dummyMatches } from '../data/dummyMatches';
+import { useNavigate } from 'react-router-dom';
 
 function Matches() {
+  const navigate = useNavigate();
+
   return (
     <div className="min-h-screen bg-background">
       <div className="h-14 bg-white shadow-sm fixed top-0 left-0 right-0 flex items-center px-4">
         <h1 className="text-lg font-bold text-center flex-1">Matches</h1>
-        <button className="w-8 h-8">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-        </button>
       </div>
-      
-      <div className="pt-14 px-4">
-        <div className="flex flex-col items-center justify-center min-h-[60vh]">
-          <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="#666666" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-          <p className="text-gray mt-4">No matches yet. Like someone to start matching!</p>
-        </div>
+
+      <div className="pt-14 px-4 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {dummyMatches.map((u) => (
+          <div key={u.id} className="card flex items-center space-x-4">
+            <img src={u.avatar} alt={u.displayName} className="w-12 h-12 rounded-full" />
+            <div className="flex-1">
+              <h3 className="font-medium">{u.displayName}</h3>
+              <p className="text-sm text-gray-600">{u.bio}</p>
+            </div>
+            <button className="btn text-sm px-3 py-1 h-auto" onClick={() => navigate('/chats')}>Chat</button>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add dummy conversations and matches data
- show matches on Matches page
- show conversations on Chats page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842a8f097a883339b0eda5f22c03622